### PR TITLE
fix: fixed image stretching issues in desktop and mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
 
           <div class="col-md-12" style="position: relative;" data-aos="fade-up">
             
-            <img src="images/landing_1.png" alt="Image" class="img-fluid img-absolute rounded" style="height: 550px; width: 1333px;">
+            <img src="images/landing_1.png" alt="Image" class="img-fluid img-absolute rounded" style="height: 550px; width: 1333px; object-fit:cover;">
 
             <div class="row mb-4">
               <div class="col-lg-4 mr-auto">


### PR DESCRIPTION
hi @ankit404 I noticed one issue in the main image (stretching in desktop and mobile), so created a fix for that, please have a look, 

**Before:**

![Screenshot 2022-10-03 at 3 54 23 PM](https://user-images.githubusercontent.com/43133456/193556794-0596779b-368a-4512-8f04-3d1ee87b2ffa.png)

![Screenshot 2022-10-03 at 3 54 32 PM](https://user-images.githubusercontent.com/43133456/193556812-73138413-f63d-4f0e-a138-cad46e016218.png)


**After:**

<img width="1550" alt="image" src="https://user-images.githubusercontent.com/43133456/193556980-4f8628d5-fc2a-4aef-bbd6-088ec0bdb970.png">

<img width="451" alt="image" src="https://user-images.githubusercontent.com/43133456/193557051-f7dc7079-56cd-4c6d-b7a8-3b5c72e6e4d5.png">



